### PR TITLE
Fix installer exit on non-Windows

### DIFF
--- a/MedAI_Radiologia_Installer.py
+++ b/MedAI_Radiologia_Installer.py
@@ -16,7 +16,6 @@ import tempfile
 
 if os.name != 'nt':
     print("❌ Este instalador é específico para Windows")
-    input("Pressione Enter para sair...")
     sys.exit(1)
 
 try:


### PR DESCRIPTION
## Summary
- remove user prompt when running MedAI_Radiologia_Installer.py on non‑Windows hosts

## Testing
- `python test_python_installer.py`
- `python MedAI_Radiologia_Installer.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ebf74670832ba688365269ca076a