### PR TITLE
Fix optional dependency handling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -43,25 +43,40 @@ def setup_application():
 
 def check_system_requirements():
     """Verifica requisitos do sistema"""
+    missing = []
     try:
-        import tensorflow as tf
-        import numpy as np
-        import pydicom
-        import cv2
-        import PIL
-        
-        logger.info("Todos os módulos necessários estão disponíveis")
-        
+        import numpy  # noqa: F401
+    except ImportError:
+        missing.append('numpy')
+
+    try:
+        import pydicom  # noqa: F401
+    except ImportError:
+        missing.append('pydicom')
+
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        missing.append('opencv-python')
+
+    try:
+        import PIL  # noqa: F401
+    except ImportError:
+        missing.append('Pillow')
+
+    try:
+        import tensorflow as tf  # noqa: F401
         if tf.config.list_physical_devices('GPU'):
             logger.info("GPU detectada e disponível para TensorFlow")
-        else:
-            logger.info("Executando em modo CPU")
-            
-        return True
-        
-    except ImportError as e:
-        logger.error(f"Módulo necessário não encontrado: {e}")
+    except ImportError:
+        logger.warning("TensorFlow não disponível - funcionalidades de IA limitadas")
+
+    if missing:
+        logger.error(f"Módulos ausentes: {', '.join(missing)}")
         return False
+
+    logger.info("Todos os módulos essenciais disponíveis")
+    return True
 
 def main():
     """Função principal"""

--- a/src/medai_setup_initialize.py
+++ b/src/medai_setup_initialize.py
@@ -3,13 +3,28 @@ MedAI Setup & Initialize - Script de Configuração Inicial
 Cria estrutura de diretórios, usuários padrão e modelos de exemplo
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import json
 import shutil
 from pathlib import Path
 import numpy as np
-import tensorflow as tf
+try:
+    import tensorflow as tf  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    tf = None  # type: ignore
+
+
+class DummyModel:
+    """Modelo de placeholder utilizado quando TensorFlow não está disponível."""
+
+    def save(self, *args, **kwargs):
+        pass
+
+    def save_weights(self, *args, **kwargs):
+        pass
 from datetime import datetime
 import sqlite3
 import bcrypt
@@ -334,6 +349,10 @@ class MedAISetup:
         """Cria modelos de exemplo pré-treinados"""
         # Para demonstração, criamos modelos pequenos com pesos aleatórios
         # Em produção, estes seriam modelos realmente treinados
+
+        if tf is None:
+            console.print("⚠️  TensorFlow não disponível - modelos de exemplo não serão criados")
+            return
         
         models_to_create = [
             ('densenet', self._create_densenet_model),
@@ -363,6 +382,8 @@ class MedAISetup:
     
     def _create_densenet_model(self):
         """Cria modelo DenseNet simplificado"""
+        if tf is None:
+            return DummyModel()
         base_model = tf.keras.applications.DenseNet121(
             weights=None,  # Sem pesos pré-treinados para demo
             include_top=False,
@@ -387,6 +408,8 @@ class MedAISetup:
     
     def _create_resnet_model(self):
         """Cria modelo ResNet simplificado"""
+        if tf is None:
+            return DummyModel()
         base_model = tf.keras.applications.ResNet50(
             weights=None,
             include_top=False,
@@ -412,6 +435,8 @@ class MedAISetup:
     def _create_efficientnet_model(self):
         """Cria modelo EfficientNet simplificado"""
         # Modelo customizado simples (EfficientNet requer instalação adicional)
+        if tf is None:
+            return DummyModel()
         model = tf.keras.Sequential([
             tf.keras.layers.Conv2D(32, 3, padding='same', activation='relu', input_shape=(224, 224, 3)),
             tf.keras.layers.BatchNormalization(),
@@ -437,6 +462,8 @@ class MedAISetup:
     
     def _create_custom_cnn_model(self):
         """Cria modelo CNN customizado"""
+        if tf is None:
+            return DummyModel()
         model = tf.keras.Sequential([
             tf.keras.layers.Conv2D(32, 3, padding='same', activation='relu', input_shape=(224, 224, 3)),
             tf.keras.layers.MaxPooling2D(),
@@ -461,6 +488,8 @@ class MedAISetup:
     def _create_attention_unet_model(self):
         """Cria modelo U-Net com atenção simplificado"""
         # Para segmentação - modelo simplificado
+        if tf is None:
+            return DummyModel()
         inputs = tf.keras.layers.Input(shape=(256, 256, 1))
         
         # Encoder


### PR DESCRIPTION
## Summary
- make TensorFlow an optional dependency by using dummy models
- avoid import errors in system setup by checking for modules first
- adjust startup requirement checks to be non-fatal when optional modules are missing

## Testing
- `python -m py_compile src/medai_sota_models.py src/medai_setup_initialize.py`
- `/usr/bin/python3 verify_final_imports.py`
- `/usr/bin/python3 src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68452febe0e8832b89a9fde12aa4317f