### PR TITLE
Fix Windows installer spec path

### DIFF
--- a/build_installer_windows.bat
+++ b/build_installer_windows.bat
@@ -20,7 +20,7 @@ pip install pyinstaller
 REM Construir executável
 echo.
 echo Construindo instalador executável...
-pyinstaller MedAI_Installer.spec
+pyinstaller build\MedAI_Radiologia.spec
 
 if %ERRORLEVEL% EQU 0 (
     echo.


### PR DESCRIPTION
## Summary
- ensure Windows batch script uses the actual PyInstaller spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b19e7270832ba6d7b32e91cd27e0