### PR TITLE
Fix missing Python dependencies for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.24.3
-tensorflow==2.13.0
+numpy==1.26.4
+tensorflow==2.16.1
 pydicom==2.4.3
-opencv-python==4.8.1
+opencv-python==4.11.0.86
 Pillow==10.1.0
 PyQt5==5.15.9
 matplotlib==3.7.2


### PR DESCRIPTION
## Summary
- update dependency versions to install on Python 3.12

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849924ad1dc832b8dbe83286ed0dc8d